### PR TITLE
Fix issue #21: UNISIG length field autocalculation

### DIFF
--- a/fervoja/application_layer/unisig/containers.py
+++ b/fervoja/application_layer/unisig/containers.py
@@ -32,6 +32,7 @@ from .interfaces import UnisigInterfaces
 class UnisigContainer(FieldContainer):
     def __init__(self, fields: OrderedDict[str, fields.Field]):
         super().__init__(fields=fields)
+        self._update_length_field()
     
     @abstractmethod
     def _update_length_field(self): pass


### PR DESCRIPTION
## 🚀 Change Description
## 🧪 Testing Performed
- [x] **Unit tests:** (Mention if you added new tests in `pytest`)
- [ ] **Static analysis:** (Mention if you ran `mypy` or `flake8`)
- [ ] **Edge cases:** (e.g., Tested with Big Endian and Little Endian in HexadecimalValue)

**Test results summary:**
Automatically updated after a pull request.

Fixes #21 

📝 Pre-submission Checklist
* [ ] Code follows the project's style guidelines.
* [ ] Comments and documentation have been updated (if applicable).
* [x] All tests pass correctly.
* [ ] No unused commented-out code.